### PR TITLE
Switch from regex-based parsing to Spirit X3 parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
             - cmake
             - lcov
             - cppcheck
-            - libboost1.67
+            - libboost1.67-dev
 
 before_script:
     - ./travis/before_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ compiler: gcc
 
 addons:
     apt:
+        sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
         packages:
             - cmake
             - lcov
             - cppcheck
-            - libboost-all-dev
+            - libboost
 
 before_script:
     - ./travis/before_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
             - cmake
             - lcov
             - cppcheck
+            - libboost-all-dev
 
 before_script:
     - ./travis/before_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
             - cmake
             - lcov
             - cppcheck
-            - libboost
+            - libboost1.67
 
 before_script:
     - ./travis/before_script.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ file(GLOB_RECURSE ${PROJECT_NAME}_HEADERS "include/*.hpp")
 add_library(${PROJECT_NAME} INTERFACE)
 target_sources(${PROJECT_NAME} INTERFACE ${${PROJECT_NAME}_HEADERS})
 target_include_directories(${PROJECT_NAME} INTERFACE include)
-target_link_libraries(${PROJECT_NAME} INTERFACE Boost::headers)
+target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
 
 if (${PROJECT_NAME}_ENABLE_TESTING)
     file(GLOB_RECURSE ${PROJECT_NAME}_TEST_SOURCES "test/*.[ch]pp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,20 @@ option(${PROJECT_NAME}_ENABLE_TESTING "Enable Testing for ${PROJECT_NAME}" ON)
 
 add_subdirectory(ext)
 
+find_package(Boost 1.67 REQUIRED)
+
 file(GLOB_RECURSE ${PROJECT_NAME}_HEADERS "include/*.hpp")
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_sources(${PROJECT_NAME} INTERFACE ${${PROJECT_NAME}_HEADERS})
 target_include_directories(${PROJECT_NAME} INTERFACE include)
+target_link_libraries(${PROJECT_NAME} INTERFACE Boost::headers)
 
 if (${PROJECT_NAME}_ENABLE_TESTING)
     file(GLOB_RECURSE ${PROJECT_NAME}_TEST_SOURCES "test/*.[ch]pp")
-    
+
     add_executable(${PROJECT_NAME}Test ${${PROJECT_NAME}_TEST_SOURCES})
-    set_target_properties(${PROJECT_NAME}Test PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES)
+    set_target_properties(${PROJECT_NAME}Test PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED YES)
     target_link_libraries(${PROJECT_NAME}Test ${PROJECT_NAME} gtest gtest_main)
     target_compile_options(${PROJECT_NAME}Test PRIVATE -g -O0 --coverage)
     set_target_properties(${PROJECT_NAME}Test PROPERTIES LINK_FLAGS "--coverage")

--- a/include/sini.hpp
+++ b/include/sini.hpp
@@ -96,6 +96,8 @@ namespace sini
             namespace x3 = boost::spirit::x3;
 
             using x3::rule;
+
+            // X3 built-in parsers
             using x3::char_;
             using x3::space;
             using x3::eps;
@@ -106,42 +108,63 @@ namespace sini
 
             using boost::fusion::at_c;
 
+            // pointer to current section (used in the setProp semantic action)
             auto curSection = &addSection("");
 
-            auto concat = [](auto& ab){ return at_c<0>(ab) + at_c<1>(ab); };
-
+            // semantic action: begins a new section
             auto startSection = [&](auto& ctx){ curSection = &addSection(_attr(ctx)); };
+
+            // semantic action: sets a property on the current section
             auto setProp = [&](auto& ctx){ curSection->set(at_c<0>(_attr(ctx)), at_c<1>(_attr(ctx))); };
 
+            // whitepsace
             auto ws = char_(" \t");
+            // whitespace including newline
             auto wsn = ws | eol;
 
+            // string enclosed in single quotes, value doesn't include the quotes
             auto singleQuotedValue = '\'' >> *char_ > '\'';
+            // string enclosed in double quotes, value doesn't include the quotes
             auto doubleQuotedValue = '"' >> *char_ > '"';
 
+            // a chunk of text which doesn't contain whitespace
             auto textChunk = +(char_ - wsn);
+
+            // a sequence of textChunks separated by whitespace
             auto rawValue = textChunk >> *(+ws >> textChunk);
 
+            // property key name
             auto propKey
                 = rule<struct propKey, std::string>{"propKey"}
                 = lexeme[ char_("a-zA-Z.$:") > *char_("a-zA-Z0-9._~\\-$: ") ];
 
+            // property value
             auto propValue
                 = rule<struct propValue, std::string>{"propValue"}
                 = lexeme[ singleQuotedValue | doubleQuotedValue | rawValue | eps ];
 
+            // section header, semantic value doesn't include the brackets
             auto sectionHeader = '[' > +(char_ - ']') > ']';
+
+            // property definition
             auto property = propKey > '=' > propValue;
+
+            // comment
             auto comment = ';' > *(char_ - eol);
 
+            // a line containing either a section header or property definition (or nothing), and an optional comment
             auto line = -(sectionHeader[startSection] | property[setProp]) >> -comment;
 
+            // whole INI file
             auto iniFile
                 = rule<_detail::error_handler>{"iniFile"}
                 = line % eol;
 
+            // current iterator into ini, should be equal to enditer when done
             auto iter = begin(ini);
-            auto enditer = end(ini);
+            // end of ini file
+            const auto enditer = end(ini);
+            // output stream for errors, used to form exception messages
             auto err = std::ostringstream{};
 
             using x3::phrase_parse;
@@ -149,12 +172,16 @@ namespace sini
             using x3::error_handler_tag;
             using error_handler_type = x3::error_handler<std::string::const_iterator>;
 
+            // default error handler
             auto error_handler = error_handler_type(iter, enditer, err);
 
+            // top-level parser, wraps iniFile with error handling
             auto parser = with<error_handler_tag>(std::ref(error_handler))[ iniFile ];
 
+            // parse the input
             auto r = phrase_parse(iter, enditer, parser, ws);
 
+            // if the parsing failed, or we somehow didn't reach the end, throw an exception
             if (!r || iter != enditer)
             {
                 throw ParseError(err.str());

--- a/include/sini.hpp
+++ b/include/sini.hpp
@@ -1,13 +1,39 @@
 #ifndef SINI_HPP
 #define SINI_HPP
 
-#include <regex>
+#define BOOST_SPIRIT_X3_NO_FILESYSTEM
+#include <boost/spirit/home/x3.hpp>
+#include <boost/spirit/home/x3/support/utility/error_reporting.hpp>
+
 #include <map>
 #include <string>
 #include <sstream>
 
 namespace sini
 {
+    class ParseError : public std::runtime_error
+    {
+    public:
+        using runtime_error::runtime_error;
+    };
+
+    namespace _detail
+    {
+        namespace x3 = boost::spirit::x3;
+
+        struct error_handler
+        {
+            template <typename I, typename E, typename C>
+            x3::error_handler_result on_error(I& first, const I& last, const E& x, const C& context)
+            {
+                auto& error_handler = x3::get<x3::error_handler_tag>(context).get();
+                std::string message = "Error! Expecting: " + x.which() + " here:";
+                error_handler(x.where(), message);
+                return x3::error_handler_result::fail;
+            }
+        };
+    }
+
     class Section
     {
         std::map<std::string, std::string> m_properties;
@@ -67,29 +93,71 @@ namespace sini
 
         inline void parse(const std::string& ini)
         {
-            std::regex sectionRegex(R"(^(?:\[([^\]]*)\]\r?\n)?([^\[]*))");
-            std::regex propertyRegex(R"([ \t]*([a-zA-Z.$:][a-zA-Z0-9_~\-.:$ ]*?)[ \t]*=[ \t]*['"]?([^\n]+)['"]?[ \t]*(?:;[^\n]*)?[ \t]*)");
-            std::smatch sectionResults;
-            std::smatch propertyResults;
+            namespace x3 = boost::spirit::x3;
 
-            for (std::string::const_iterator ini_iter = ini.cbegin();
-                 std::regex_search(ini_iter, ini.cend(), sectionResults, sectionRegex) && ini_iter < ini.cend();
-                 ini_iter = sectionResults[0].second)
+            using x3::rule;
+            using x3::char_;
+            using x3::space;
+            using x3::eps;
+            using x3::eol;
+            using x3::eoi;
+            using x3::lexeme;
+            using x3::omit;
+
+            using boost::fusion::at_c;
+
+            auto curSection = &addSection("");
+
+            auto concat = [](auto& ab){ return at_c<0>(ab) + at_c<1>(ab); };
+
+            auto startSection = [&](auto& ctx){ curSection = &addSection(_attr(ctx)); };
+            auto setProp = [&](auto& ctx){ curSection->set(at_c<0>(_attr(ctx)), at_c<1>(_attr(ctx))); };
+
+            auto ws = char_(" \t");
+            auto wsn = ws | eol;
+
+            auto singleQuotedValue = '\'' >> *char_ > '\'';
+            auto doubleQuotedValue = '"' >> *char_ > '"';
+
+            auto textChunk = +(char_ - wsn);
+            auto rawValue = textChunk >> *(+ws >> textChunk);
+
+            auto propKey
+                = rule<struct propKey, std::string>{"propKey"}
+                = lexeme[ char_("a-zA-Z.$:") > *char_("a-zA-Z0-9._~\\-$: ") ];
+
+            auto propValue
+                = rule<struct propValue, std::string>{"propValue"}
+                = lexeme[ singleQuotedValue | doubleQuotedValue | rawValue | eps ];
+
+            auto sectionHeader = '[' > +(char_ - ']') > ']';
+            auto property = propKey > '=' > propValue;
+            auto comment = ';' > *(char_ - eol);
+
+            auto line = -(sectionHeader[startSection] | property[setProp]) >> -comment;
+
+            auto iniFile
+                = rule<_detail::error_handler>{"iniFile"}
+                = line % eol;
+
+            auto iter = begin(ini);
+            auto enditer = end(ini);
+            auto err = std::ostringstream{};
+
+            using x3::phrase_parse;
+            using x3::with;
+            using x3::error_handler_tag;
+            using error_handler_type = x3::error_handler<std::string::const_iterator>;
+
+            auto error_handler = error_handler_type(iter, enditer, err);
+
+            auto parser = with<error_handler_tag>(std::ref(error_handler))[ iniFile ];
+
+            auto r = phrase_parse(iter, enditer, parser, ws);
+
+            if (!r || iter != enditer)
             {
-                std::string sectionName = sectionResults[1];
-                std::string sectionText = sectionResults[2];
-
-                Section& section = addSection(sectionName);
-
-                for (std::string::const_iterator section_iter = sectionText.cbegin();
-                     std::regex_search(section_iter, sectionText.cend(), propertyResults, propertyRegex) && section_iter < sectionText.cend();
-                     section_iter = propertyResults[0].second)
-                {
-                    std::string propertyName = propertyResults[1];
-                    std::string propertyText = propertyResults[2];
-
-                    section.set(propertyName, propertyText);
-                }
+                throw ParseError(err.str());
             }
         }
 

--- a/test/sini.cpp
+++ b/test/sini.cpp
@@ -32,26 +32,15 @@ namespace sini
         TEST(sini, ParseError)
         {
             Sini sini;
-            try
-            {
+            EXPECT_THROW((
                 sini.parse(
                     "a=b\n"
                     "\n"
                     "[asdf\n" // intentionally forgot the closing bracket
                     "e=f\n"
                     "\n"
-                );
-
-                FAIL() << "Expected parsing to throw.";
-            }
-            catch (const sini::ParseError&)
-            {
-                // success!
-            }
-            catch (...)
-            {
-                FAIL() << "Expected ParseError exception type.";
-            }
+                )),
+                sini::ParseError);
         }
     }
 }

--- a/test/sini.cpp
+++ b/test/sini.cpp
@@ -28,5 +28,30 @@ namespace sini
                 "\n"
             );
         }
+
+        TEST(sini, ParseError)
+        {
+            Sini sini;
+            try
+            {
+                sini.parse(
+                    "a=b\n"
+                    "\n"
+                    "[asdf\n" // intentionally forgot the closing bracket
+                    "e=f\n"
+                    "\n"
+                );
+
+                FAIL() << "Expected parsing to throw.";
+            }
+            catch (const sini::ParseError&)
+            {
+                // success!
+            }
+            catch (...)
+            {
+                FAIL() << "Expected ParseError exception type.";
+            }
+        }
     }
 }


### PR DESCRIPTION
Regexes are not great for parsing. They quicky become unreadable and unmaintainable, due to a lack of structure.

The current regexes are already getting messy, and they are lacking many INI features. They currently can't handle quoted strings (very well), comments, or escape sequences.

Fixing these problems would result in extremely large and repetitive regexes that would certainly be impossible to debug.

Additionally, regex offers no real mechanism for error reporting, meaning that invalid INI files will usually pass with incomplete data.

Therefore, I suggest switching to a PEG or similar parser.

The easiest option, in my opinion, would be Bison and RE/flex, due to Bison's grammar being simpler to work with. However, since Sini seems to be aiming to be header-only, I have chosen Boost Spirit X3, which uses PEG, and is entirely represented in C++.

Aside from an optional dependency on Boost Filesystem (which I have disabled), X3 is entirely header-only itself, and doesn't seem to significantly impact compile times or cause bloat.