### PR TITLE
Directly adds Spirit from Boost 1.72.0 in ext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,14 @@ option(${PROJECT_NAME}_ENABLE_TESTING "Enable Testing for ${PROJECT_NAME}" OFF)
 
 add_subdirectory(ext)
 
-find_package(Boost 1.67 REQUIRED)
+#find_package(Boost 1.67 REQUIRED)
 
 file(GLOB_RECURSE ${PROJECT_NAME}_HEADERS "include/*.hpp")
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_sources(${PROJECT_NAME} INTERFACE ${${PROJECT_NAME}_HEADERS})
-target_include_directories(${PROJECT_NAME} INTERFACE include)
-target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
+target_include_directories(${PROJECT_NAME} INTERFACE include ext/spirit/include)
+#target_link_libraries(${PROJECT_NAME} INTERFACE Boost::boost)
 
 if (${PROJECT_NAME}_ENABLE_TESTING)
     file(GLOB_RECURSE ${PROJECT_NAME}_TEST_SOURCES "test/*.[ch]pp")


### PR DESCRIPTION
Adds Boost.Spirit as a "submodule" of `sini`.

Due to issues with the `git submodule` command and to add the license, Boost.Spirit was added to the `ext` directory using the release tarball for Boost 1.72.0.

The necessary `CMakeLists.txt` files have been updated to ensure this version of Boost.Spirit is used instead of the system version.

These changes have been tested for compilation using [EmbComPython](https://github.com/xxAtrain223/EmbComPython).